### PR TITLE
Migrate all DNS records which reference a specific server

### DIFF
--- a/hover/client.py
+++ b/hover/client.py
@@ -11,9 +11,8 @@ import requests
 class HoverException(Exception):
     pass
 
-
-class HoverClient(object):
-    def __init__(self, username, password, domain_name):
+class HoverAPI(object):
+    def __init__(self, username, password):
 
         params = {"username": username, "password": password}
         r = requests.post("https://www.hover.com/api/login", params=params)
@@ -21,6 +20,26 @@ class HoverClient(object):
         if not r.ok or "hoverauth" not in r.cookies:
             raise HoverException("{0}:{1}".format(r.status_code, r.json()["error"]))
         self.cookies = {"hoverauth": r.cookies["hoverauth"]}
+
+    def call(self, method, resource, data=None):
+        url = "https://www.hover.com/api/{0}".format(resource)
+        r = requests.request(method, url, data=data, cookies=self.cookies)
+
+        if not r.ok:
+            raise HoverException("{0}:{1}".format(r.status_code, r.json()["error"]))
+        if r.content:
+            body = r.json()
+            if "succeeded" not in body or body["succeeded"] is not True:
+                raise HoverException(body)
+            return body
+
+    def get_list_of_domains(self):
+        return (current_domain["domain_name"] for current_domain in self.call("get", "domains")["domains"])
+
+class HoverClient(HoverAPI):
+
+    def __init__(self, username, password, domain_name):
+        HoverAPI.__init__(self, username, password)
 
         dns = self.call("get", "dns")
         self.domain = None
@@ -36,21 +55,12 @@ class HoverClient(object):
     def dns_id(self):
         return self.domain["id"]
 
-    def call(self, method, resource, data=None):
-        url = "https://www.hover.com/api/{0}".format(resource)
-        r = requests.request(method, url, data=data, cookies=self.cookies)
-
-        if not r.ok:
-            raise HoverException("{0}:{1}".format(r.status_code, r.json()["error"]))
-        if r.content:
-            body = r.json()
-            if "succeeded" not in body or body["succeeded"] is not True:
-                raise HoverException(body)
-            return body
-
     def add_record(self, type, name, content):
         record = {"name": name, "type": type, "content": content}
         return self.call("post", "domains/{0}/dns".format(self.dns_id), record)
+
+    def get_all_records(self):
+        return self.call("get", "domains/{0}/dns".format(self.dns_id))["domains"][0]["entries"]
 
     def get_record(self, type, name):
 
@@ -65,14 +75,17 @@ class HoverClient(object):
 
         return None
 
+    def update_record_by_id(self, record_id, content):
+        return self.call("put",
+                         "dns/{0}".format(record_id),
+                         {"content": content})
+
     def update_record(self, type, name, content):
 
         record = self.get_record(type, name)
 
         if record is not None:
-            return self.call("put",
-                             "dns/{0}".format(record["id"]),
-                             {"content": content})
+            return self.update_record_by_id(record["id"],)
         else:
             raise HoverException("Record not found")
 

--- a/migrate-server-dns.py
+++ b/migrate-server-dns.py
@@ -1,0 +1,34 @@
+import argparse
+from hover.client import HoverAPI, HoverClient
+
+parser = argparse.ArgumentParser(description="Grabs all DNS records from hover, filters by the content of the DNS record then updates the content to a new value.")
+parser.add_argument("--hover_username", required=True)
+parser.add_argument("--hover_password", required=True)
+parser.add_argument("--dry_run", action="store_true")
+parser.add_argument("--search_term", required=True, help="The current domain that you want to replace all references to")
+parser.add_argument("--replacement_domain", required=True, help="The replacement domain")
+args = parser.parse_args()
+
+hAPI = HoverAPI(username=args.hover_username, password=args.hover_password)
+
+domain_names = hAPI.get_list_of_domains()
+
+OUTPUT_PREFIX = "Repointing "
+
+if args.dry_run:
+    OUTPUT_PREFIX = "Would repoint "
+
+for current_domain_name in domain_names:
+    domain_client = HoverClient(username=args.hover_username, password=args.hover_password, domain_name=current_domain_name)
+
+    dns_records = domain_client.get_all_records()
+
+    for current_record in dns_records:
+
+        if args.search_term in current_record["content"]:
+            full_domain = current_record["name"] + "." + current_domain_name
+
+            print OUTPUT_PREFIX + full_domain + " (" + current_record["id"] + " : " + current_record["content"] + ")"
+
+            if not args.dry_run:
+                domain_client.update_record_by_id(current_record["id"], args.replacement_domain)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="hover-client",
-    version="0.1",
+    version="0.2",
     description="Python client for the undocumented, unofficial Hover.com API.",
     author="Chris Young - based on work by Dan Krause",
     license="LICENSE.md",


### PR DESCRIPTION
Modify script to enable access to the full Hover API rather than enforcing per-domain level access. 

Add new script which allows migration of all references to a server. If there are N CNAME records which point to a.com this can repoint all N cnames to point to a new address instead. Useful for migrating between servers
